### PR TITLE
Configure horizontal screws per edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,14 +649,14 @@ Vertical screw locations can be combined as needed. A common combination would b
 
 ## Horizontal Screws
 
-Horizontal screws are used to attach the plate on the side. At the moment, it is only possible to place screws on [plate walls](#plate-wall). Enable screws with the `horizontal_screw_wall` option. This requires `plate_wall_thickness` to be set for the relevant wall. The screws will be placed in the middle of each cell.
+Horizontal screws are used to attach the plate on the side. Enable screws for individual edges with the `horizontal_screw_wall_north`, `horizontal_screw_wall_east`, `horizontal_screw_wall_south`, and `horizontal_screw_wall_west` options. The screws will be placed in the middle of each cell.
 
-<!-- openscad -o docs/images/hscrews.png --camera=0,0,0,40,0,10,400 -D plate_size='[84, 84]' -D plate_wall_thickness='[3, 0, 0, 0]' -D plate_wall_height='[5, 0]' -D horizontal_screw_wall=true -->
+<!-- openscad -o docs/images/hscrews.png --camera=0,0,0,40,0,10,400 -D plate_size='[84, 84]' -D plate_wall_thickness='[3, 0, 0, 0]' -D plate_wall_height='[5, 0]' -D horizontal_screw_wall_north=true -->
 <img src="docs/images/hscrews.png" alt="Horizontal screws" />
 
 Similar to vertical screws, the screw head can be customized with `horizontal_screw_countersink_top` and `horizontal_screw_counterbore_top`. 
 
-The exact hole position can be adjusted using `horizontal_screw_offset`. By default, the hole will be centered on any wall.
+The exact hole position can be adjusted using `horizontal_screw_offset`. By default, the hole will be centered vertically on the plate or any wall.
 
 ## Thumb Screw
 

--- a/editor.toml
+++ b/editor.toml
@@ -178,22 +178,21 @@ help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#other-inter
 
 [model.tab-metadata."Horizontal Screws"]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
-control-boolean = "horizontal_screw_wall"
-description-html = "Enable horizontal screws on plate walls. Requires plate_wall_thickness."
-[model.param-metadata.horizontal_screw_wall]
-display-condition = {fixed = false}
+description-html = "Add horizontal screw holes to selected plate edges."
+[model.param-metadata."horizontal_screw_wall_*"]
+help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
 [model.param-metadata.horizontal_screw_diameter]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
-display-condition = {js = "horizontal_screw_wall"}
+display-condition = {js = "horizontal_screw_wall_north || horizontal_screw_wall_east || horizontal_screw_wall_south || horizontal_screw_wall_west"}
 [model.param-metadata.horizontal_screw_countersink_top]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
-display-condition = {js = "horizontal_screw_wall"}
+display-condition = {js = "horizontal_screw_wall_north || horizontal_screw_wall_east || horizontal_screw_wall_south || horizontal_screw_wall_west"}
 [model.param-metadata.horizontal_screw_counterbore_top]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
-display-condition = {js = "horizontal_screw_wall"}
+display-condition = {js = "horizontal_screw_wall_north || horizontal_screw_wall_east || horizontal_screw_wall_south || horizontal_screw_wall_west"}
 [model.param-metadata.horizontal_screw_offset]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
-display-condition = {js = "horizontal_screw_wall"}
+display-condition = {js = "horizontal_screw_wall_north || horizontal_screw_wall_east || horizontal_screw_wall_south || horizontal_screw_wall_west"}
 
 [model.tab-metadata."Thumb Screw"]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#thumb-screw"

--- a/editor.toml
+++ b/editor.toml
@@ -179,6 +179,7 @@ help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#other-inter
 [model.tab-metadata."Horizontal Screws"]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
 description-html = "Add horizontal screw holes to selected plate edges."
+collapsed = true
 [model.param-metadata."horizontal_screw_wall_*"]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
 [model.param-metadata.horizontal_screw_diameter]

--- a/editor.toml
+++ b/editor.toml
@@ -178,7 +178,6 @@ help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#other-inter
 
 [model.tab-metadata."Horizontal Screws"]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"
-description-html = "Add horizontal screw holes to selected plate edges."
 collapsed = true
 [model.param-metadata."horizontal_screw_wall_*"]
 help-link = "https://github.com/yawkat/GridFlock/blob/main/README.md#horizontal-screws"

--- a/gridflock.scad
+++ b/gridflock.scad
@@ -160,8 +160,14 @@ vertical_screw_other = false;
 
 /* [Horizontal Screws] */
 
-// Enable horizontal screws on plate walls (requires plate_wall_thickness)
-horizontal_screw_wall = false;
+// Enable horizontal screws on the north edge
+horizontal_screw_wall_north = false;
+// Enable horizontal screws on the east edge
+horizontal_screw_wall_east = false;
+// Enable horizontal screws on the south edge
+horizontal_screw_wall_south = false;
+// Enable horizontal screws on the west edge
+horizontal_screw_wall_west = false;
 // Radius of vertical screws
 horizontal_screw_diameter = 3.2; // 0.1
 // Top countersink dimension. First value is the diameter of the screw head, second value the height
@@ -847,9 +853,10 @@ module vertical_screw() {
     translate([0, 0, _profile_height]) screw(depth=_total_height, d=vertical_screw_diameter, countersink=vertical_screw_countersink_top, counterbore=vertical_screw_counterbore_top);
 }
 
-module horizontal_screws(direction, padding, trace) {
+module horizontal_screws(direction, padding, trace, connector) {
     wall = plate_wall_thickness[direction];
-    if (horizontal_screw_wall && wall > 0 && padding[direction] > 0) {
+    enabled = [horizontal_screw_wall_north, horizontal_screw_wall_east, horizontal_screw_wall_south, horizontal_screw_wall_west];
+    if (enabled[direction] && !connector[direction]) {
         direction_left = (direction + 3) % 4;
         direction_right = (direction + 1) % 4;
         cumulated = cumulate(trace);
@@ -1139,10 +1146,10 @@ module segment(trace=[[1], [1]], padding=[0, 0, 0, 0], connector=[false, false, 
         }
 
         // horizontal screw holes
-        translate([0, size.y/2]) horizontal_screws(_NORTH, padding, trace = trace.x);
-        translate([0, -size.y/2]) rotate([0, 0, 180]) horizontal_screws(_SOUTH, padding, trace = trace.x);
-        translate([-size.x/2, 0]) rotate([0, 0, 90]) horizontal_screws(_WEST, padding, trace = trace.y);
-        translate([size.x/2, 0]) rotate([0, 0, -90]) horizontal_screws(_EAST, padding, trace = trace.y);
+        translate([0, size.y/2]) horizontal_screws(_NORTH, padding, trace = trace.x, connector = connector);
+        translate([0, -size.y/2]) rotate([0, 0, 180]) horizontal_screws(_SOUTH, padding, trace = trace.x, connector = connector);
+        translate([-size.x/2, 0]) rotate([0, 0, 90]) horizontal_screws(_WEST, padding, trace = trace.y, connector = connector);
+        translate([size.x/2, 0]) rotate([0, 0, -90]) horizontal_screws(_EAST, padding, trace = trace.y, connector = connector);
     }
 }
 


### PR DESCRIPTION
## Summary

- replace the single horizontal screw toggle with north, east, south, and west booleans
- allow horizontal holes to cut directly into the grid when no plate wall is present
- restrict holes to outer plate edges instead of internal segment connector edges
- update the web editor configuration and README example

## Validation

- just test
- editor.toml schema and parameter metadata validation
- manifold wall-mounted example render with hard warnings
- manifold four-segment render confirming holes only on the outer perimeter
- git diff --check